### PR TITLE
add engine builder node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,6 +7,7 @@ from comfy.utils import ProgressBar
 from .utilities import Engine
 from .yolo_nas_pose.pose_estimation import PoseVisualization
 import cv2
+from .engine_builder_node import YoloNasPoseEngineBuilder
 
 ENGINE_DIR = os.path.join(folder_paths.models_dir,
                           "tensorrt", "yolo-nas-pose")
@@ -62,10 +63,14 @@ def show_predictions_from_batch_format(predictions):
 class YoloNasPoseTensorrt:
     @classmethod
     def INPUT_TYPES(s):
+        try:
+            engines = os.listdir(ENGINE_DIR)
+        except FileNotFoundError:
+            engines = []
         return {
             "required": {
                 "images": ("IMAGE",),
-                "engine": (os.listdir(ENGINE_DIR),),
+                "engine": (engines,),
             }
         }
     RETURN_NAMES = ("IMAGE",)
@@ -124,10 +129,12 @@ class YoloNasPoseTensorrt:
 
 NODE_CLASS_MAPPINGS = {
     "YoloNasPoseTensorrt": YoloNasPoseTensorrt,
+    "YoloNasPoseEngineBuilder": YoloNasPoseEngineBuilder,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "YoloNasPoseTensorrt": "Yolo Nas Pose Tensorrt",
+    "YoloNasPoseEngineBuilder": "Yolo Nas Pose Engine Builder",
 }
 
 __all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']

--- a/engine_builder_node.py
+++ b/engine_builder_node.py
@@ -1,0 +1,136 @@
+import os
+import folder_paths
+from .export_trt import export_trt
+import urllib.request
+import shutil
+
+ENGINE_DIR = os.path.join(folder_paths.models_dir, "tensorrt", "yolo-nas-pose")
+ONNX_DIR = os.path.join(folder_paths.models_dir, "onnx", "yolo-nas-pose")
+
+# Model URLs and configurations
+YOLO_NAS_POSE_MODELS = {
+    "large_0.1": {
+        "url": "https://huggingface.co/yuvraj108c/yolo-nas-pose-onnx/resolve/main/yolo_nas_pose_l_0.1.onnx",
+        "filename": "yolo_nas_pose_l_0.1.onnx",
+        "engine_name": "yolo_nas_pose_l_0.1-fp16.engine"
+    },
+    "large_0.2": {
+        "url": "https://huggingface.co/yuvraj108c/yolo-nas-pose-onnx/resolve/main/yolo_nas_pose_l_0.2.onnx",
+        "filename": "yolo_nas_pose_l_0.2.onnx",
+        "engine_name": "yolo_nas_pose_l_0.2-fp16.engine"
+    },
+    "large_0.35": {
+        "url": "https://huggingface.co/yuvraj108c/yolo-nas-pose-onnx/resolve/main/yolo_nas_pose_l_0.35.onnx",
+        "filename": "yolo_nas_pose_l_0.35.onnx",
+        "engine_name": "yolo_nas_pose_l_0.35-fp16.engine"
+    },
+    "large_0.5": {
+        "url": "https://huggingface.co/yuvraj108c/yolo-nas-pose-onnx/resolve/main/yolo_nas_pose_l_0.5.onnx",
+        "filename": "yolo_nas_pose_l_0.5.onnx",
+        "engine_name": "yolo_nas_pose_l_0.5-fp16.engine"
+    },
+    "large_0.8": {
+        "url": "https://huggingface.co/yuvraj108c/yolo-nas-pose-onnx/resolve/main/yolo_nas_pose_l_0.8.onnx",
+        "filename": "yolo_nas_pose_l_0.8.onnx",
+        "engine_name": "yolo_nas_pose_l_0.8-fp16.engine"
+    }
+}
+
+def download_onnx_model(model_key):
+    """Download ONNX model if it doesn't exist"""
+    if model_key not in YOLO_NAS_POSE_MODELS:
+        return f"Invalid model key: {model_key}", None
+    
+    model_info = YOLO_NAS_POSE_MODELS[model_key]
+    url = model_info["url"]
+    filename = model_info["filename"]
+    local_path = os.path.join(ONNX_DIR, filename)
+    
+    if os.path.exists(local_path):
+        return f"Model already exists at: {local_path}", local_path
+    
+    try:
+        print(f"Downloading model from {url} to {local_path}...")
+        
+        # Create a temporary file for downloading
+        temp_file = local_path + ".tmp"
+        
+        # Download the file
+        with urllib.request.urlopen(url) as response, open(temp_file, 'wb') as out_file:
+            shutil.copyfileobj(response, out_file)
+        
+        # Rename the temporary file to the target filename
+        shutil.move(temp_file, local_path)
+        
+        return f"Successfully downloaded model to: {local_path}", local_path
+    except Exception as e:
+        return f"Error downloading model: {str(e)}", None
+
+class YoloNasPoseEngineBuilder:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": { 
+                "model_size": (list(YOLO_NAS_POSE_MODELS.keys()), {
+                    "default": "large_0.5",
+                    "tooltip": "Select the YoloNasPose model size. Larger models provide better accuracy but require more VRAM."
+                }),
+                "custom_engine_name": ("STRING", {
+                    "default": "",
+                    "tooltip": "Optional custom name for the TensorRT engine file. If empty, will use the default name based on the model."
+                }),
+                "use_fp16": ("BOOLEAN", {
+                    "default": True,
+                    "tooltip": "Enable FP16 precision for faster inference and lower VRAM usage. Disable if you experience stability issues."
+                }),
+                "custom_onnx_path": ("STRING", {
+                    "default": "",
+                    "optional": True,
+                    "tooltip": "Optional path to a custom ONNX model file. If provided, will use this instead of downloading the predefined model."
+                }),
+            }
+        }
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("message",)
+    FUNCTION = "build_engine"
+    CATEGORY = "tensorrt"
+    OUTPUT_NODE = True
+    
+    def build_engine(self, model_size, custom_engine_name, use_fp16, custom_onnx_path=""):
+        # Ensure directories exist
+        os.makedirs(ENGINE_DIR, exist_ok=True)
+        os.makedirs(ONNX_DIR, exist_ok=True)
+        
+        # Determine ONNX path and engine name
+        if custom_onnx_path and os.path.exists(custom_onnx_path):
+            onnx_path = custom_onnx_path
+            engine_name = custom_engine_name if custom_engine_name else os.path.basename(custom_onnx_path).replace(".onnx", "-fp16.engine" if use_fp16 else ".engine")
+        else:
+            # Download and use predefined model
+            model_info = YOLO_NAS_POSE_MODELS[model_size]
+            message, onnx_path = download_onnx_model(model_size)
+            
+            if not onnx_path:
+                return (message,)
+                
+            engine_name = custom_engine_name if custom_engine_name else model_info["engine_name"]
+            if use_fp16 and not engine_name.endswith("-fp16.engine"):
+                engine_name = engine_name.replace(".engine", "-fp16.engine")
+            elif not use_fp16 and "-fp16.engine" in engine_name:
+                engine_name = engine_name.replace("-fp16.engine", ".engine")
+        
+        engine_path = os.path.join(ENGINE_DIR, engine_name)
+        
+        # Check if engine already exists
+        if os.path.exists(engine_path):
+            return (f"Engine already exists at: {engine_path}. Delete it manually if you want to rebuild.",)
+        
+        try:
+            print(f"Building TensorRT engine from {onnx_path} to {engine_path}...")
+            result = export_trt(trt_path=engine_path, onnx_path=onnx_path, use_fp16=use_fp16)
+            if result == 0:
+                return (f"Successfully built engine: {engine_path}",)
+            else:
+                return (f"Failed to build engine. Check console for details.",)
+        except Exception as e:
+            return (f"Error building engine: {str(e)}",) 

--- a/export_trt.py
+++ b/export_trt.py
@@ -1,7 +1,10 @@
 import torch
 import time
-from utilities import Engine
 
+try:
+    from .utilities import Engine
+except ImportError:
+    from utilities import Engine
 
 def export_trt(trt_path: str, onnx_path: str, use_fp16: bool):
     engine = Engine(trt_path)
@@ -20,5 +23,6 @@ def export_trt(trt_path: str, onnx_path: str, use_fp16: bool):
     return ret
 
 
-export_trt(trt_path="./yolo_nas_pose_l.engine",
-           onnx_path="./yolo_nas_pose_l.onnx", use_fp16=True)
+if __name__ == "__main__":
+    export_trt(trt_path="./yolo_nas_pose_l.engine",
+               onnx_path="./yolo_nas_pose_l.onnx", use_fp16=True)

--- a/readme.md
+++ b/readme.md
@@ -42,8 +42,19 @@ cd ./ComfyUI-YoloNasPose-Tensorrt
 pip install -r requirements.txt
 ```
 
-## 🛠️ Building Tensorrt Engine
+## 🛠️ Building TensorRT Engine
 
+There are two ways to build TensorRT engines:
+
+### Method 1: Using the EngineBuilder Node
+1. Insert node by `Right Click -> tensorrt -> Yolo Nas Pose Engine Builder`
+2. Select the model size (small, medium, or large)
+3. Optionally customize the engine name, FP16 settings, and onnx path
+4. Run the workflow to build the engine
+
+The engine will be automatically downloaded and built in the specified location. Refresh the webpage or strike 'r' on your keyboard, and the new engine will appear in the Yolo Nas Pose Tensorrt node.
+
+### Method 2: Manual Building
 1. Download one of the available [onnx models](https://huggingface.co/yuvraj108c/yolo-nas-pose-onnx/tree/main). The number at the end represents the confidence threshold for pose detection _(e.g yolo_nas_pose_l_0.5.onnx)_
 2. Edit model paths inside [export_trt.py](export_trt.py) accordingly and run `python export_trt.py`
 3. Place the exported tensorrt engine inside ComfyUI `/models/tensorrt/yolo-nas-pose` directory


### PR DESCRIPTION
# Add EngineBuilder Node for YoloNasPose-Tensorrt

## Description
This PR adds a new EngineBuilder node to the ComfyUI-YoloNasPose-Tensorrt extension, allowing users to easily build TensorRT engines from ONNX models directly in ComfyUI.

## Changes
- Created new engine builder node

## Features
- **Model Selection**: Choose from the supported ONNX models
- **Custom Engine Names**: Option to specify custom engine file names
- **Custom ONNX Models**: Support for using custom ONNX models
- **Automatic Downloads**: Auto download onnx from HF, and build engine
- **User Feedback**: Clear status messages for all operations

## Usage
1. Add the "YoloNasPose Engine Builder" node to your workflow
2. Select the desired model size
3. (Optional) Configure custom engine name and FP16 settings
4. Run the workflow to build the TensorRT engine

## Technical Details
- Models are downloaded to `models/onnx/yolo-nas-pose/`
- Engines are built in `models/tensorrt/yolo-nas-pose/`
- Supports both predefined and custom ONNX models
- Includes proper error handling and status reporting

## Testing
- Tested with some models sizes in ComfyUI (method 1)
- Tested with some model sizes by running the script directly (method 2)